### PR TITLE
Replace winapi by windows_sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,19 @@ unstable_ds4 = []
 unstable_xtarget_notification = []
 
 [dependencies]
-winapi = { version = "0.3", features = ["std", "handleapi", "setupapi", "fileapi", "winbase", "ioapiset", "synchapi", "errhandlingapi", "xinput", "winerror"] }
+
+[dependencies.windows-sys]
+version = "0.42.0"
+features = [
+    "Win32_Devices_DeviceAndDriverInstallation",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_UI_Input_XboxController",
+]
 
 [dev-dependencies]
 rusty-xinput = "1.2.0"

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,7 @@
 use std::{fmt, ptr};
-use winapi::um::handleapi::*;
-use winapi::um::synchapi::*;
-use winapi::shared::ntdef::HANDLE;
+
+use windows_sys::Win32::Foundation::*;
+use windows_sys::Win32::System::Threading::*;
 
 #[repr(transparent)]
 pub struct Event {
@@ -12,7 +12,7 @@ impl Event {
 	pub fn new(manual_reset: bool, initial_state: bool) -> Event {
 		unsafe {
 			let handle = CreateEventW(ptr::null_mut(), manual_reset as i32, initial_state as i32, ptr::null());
-			debug_assert!(!handle.is_null());
+			debug_assert!(handle != 0);
 			Event { handle }
 		}
 	}

--- a/src/x360.rs
+++ b/src/x360.rs
@@ -2,8 +2,8 @@ use std::{fmt, mem, ptr};
 #[cfg(feature = "unstable_xtarget_notification")]
 use std::{marker, pin, thread};
 use std::borrow::Borrow;
-use winapi::um::xinput::XINPUT_GAMEPAD;
-use winapi::shared::winerror;
+use windows_sys::Win32::Foundation::*;
+use windows_sys::Win32::UI::Input::XboxController::XINPUT_GAMEPAD;
 use crate::*;
 
 /// XInput compatible button flags.
@@ -262,8 +262,8 @@ impl XRequestNotification {
 					small_motor: xurn.buffer.SmallMotor,
 					led_number: xurn.buffer.LedNumber,
 				})),
-				Err(winerror::ERROR_IO_INCOMPLETE) => Ok(None),
-				Err(winerror::ERROR_OPERATION_ABORTED) => {
+				Err(ERROR_IO_INCOMPLETE) => Ok(None),
+				Err(ERROR_OPERATION_ABORTED) => {
 					// Operation was aborted, fail all future calls
 					// The is aborted when the underlying target is unplugged
 					// This has the potential for a race condition:
@@ -425,8 +425,8 @@ impl<CL: Borrow<Client>> Xbox360Wired<CL> {
 			let device = self.client.borrow().device;
 			match gui.ioctl(device, self.event.handle) {
 				Ok(()) => (),
-				// Err(winerror::ERROR_ACCESS_DENIED) => return Err(Error::InvalidTarget),
-				Err(winerror::ERROR_INVALID_DEVICE_OBJECT_PARAMETER) => return Err(Error::UserIndexOutOfRange),
+				// Err(ERROR_ACCESS_DENIED) => return Err(Error::InvalidTarget),
+				Err(ERROR_INVALID_DEVICE_OBJECT_PARAMETER) => return Err(Error::UserIndexOutOfRange),
 				Err(err) => return Err(Error::WinError(err)),
 			}
 
@@ -448,7 +448,7 @@ impl<CL: Borrow<Client>> Xbox360Wired<CL> {
 			let device = self.client.borrow().device;
 			match xsr.ioctl(device, self.event.handle) {
 				Ok(()) => Ok(()),
-				Err(winerror::ERROR_DEV_NOT_EXIST) => Err(Error::TargetNotReady),
+				Err(ERROR_DEV_NOT_EXIST) => Err(Error::TargetNotReady),
 				Err(err) => Err(Error::WinError(err)),
 			}
 		}


### PR DESCRIPTION
Nothing special to add, [windows-sys](https://crates.io/crates/windows-sys) is replacing [winapi](https://crates.io/crates/winapi) in Rust projects.

Not sure if you are interested to use this crate.