### PR TITLE
Add extended report for DS4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
 name = "notification"
 required-features = ["unstable_xtarget_notification"]
 
+[[example]]
+name = "ds4"
+required-features = ["unstable_ds4"]
+
 [features]
 # Include the DS4Target target
 unstable_ds4 = []

--- a/examples/ds4.rs
+++ b/examples/ds4.rs
@@ -1,0 +1,47 @@
+use std::{thread, time};
+
+fn main() {
+    // Connect to the ViGEmBus driver
+    let client = vigem_client::Client::connect().unwrap();
+
+    // Create the virtual controller target
+    let id = vigem_client::TargetId::DUALSHOCK4_WIRED;
+    let mut target = vigem_client::DualShock4Wired::new(client, id);
+
+    // Plugin the virtual controller
+    target.plugin().unwrap();
+
+    // Wait for the virtual controller to be ready to accept updates
+    target.wait_ready().unwrap();
+
+    // The input state of the virtual controller
+    let mut gamepad = vigem_client::DS4ReportEx {
+        ..Default::default()
+    };
+
+    let start = time::Instant::now();
+    loop {
+        let elapsed = start.elapsed().as_secs_f64();
+
+        // Play for 10 seconds
+        if elapsed >= 10.0 {
+            break;
+        }
+
+        // Spin the left thumb stick in circles
+        gamepad.thumb_lx = ((elapsed.cos() + 1.) * 127.) as u8;
+        gamepad.thumb_ly = ((elapsed.sin() + 1.) * 127.) as u8;
+
+        // Spin the right thumb stick in circles
+        gamepad.thumb_rx = gamepad.thumb_ly;
+        gamepad.thumb_ry = gamepad.thumb_lx;
+
+        // Twiddle the triggers
+        gamepad.trigger_l = ((((elapsed * 1.5).sin() * 127.0) as i32) + 127) as u8;
+        gamepad.trigger_r = ((((elapsed * 1.5).cos() * 127.0) as i32) + 127) as u8;
+
+        let _ = target.update_ex(&gamepad);
+
+        thread::sleep(time::Duration::from_millis(10));
+    }
+}

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -417,6 +417,8 @@ impl DS4SubmitReportEx {
     }
 }
 
+#[cfg(feature = "unstable_ds4")]
+const _: [(); 71] = [(); mem::size_of::<DS4SubmitReportEx>()];
 
 #[repr(C)]
 pub struct XUsbGetUserIndex {

--- a/src/ds4.rs
+++ b/src/ds4.rs
@@ -77,6 +77,10 @@ pub struct DS4ReportEx {
                         we bypass this by setting directly the padding in the struct */
 }
 
+// Assert that the struct is 63 bytes long
+#[cfg(feature = "unstable_ds4")]
+const _: [(); 63] = [(); mem::size_of::<DS4ReportEx>()];
+
 #[cfg(feature = "unstable_ds4")]
 impl Default for DS4ReportEx {
     #[inline]

--- a/src/ds4.rs
+++ b/src/ds4.rs
@@ -245,6 +245,7 @@ impl<CL: Borrow<Client>> DualShock4Wired<CL> {
 		Ok(())
 	}
 
+    /// Updates the virtual controller state using the extended report.
     #[inline(never)]
     #[cfg(feature = "unstable_ds4")]
     pub fn update_ex(&mut self, report: &DS4ReportEx) -> Result<(), Error> {


### PR DESCRIPTION
Use the previously commented code for extended report and add the necessary `#[packed]` attributes.